### PR TITLE
added warning to old panels

### DIFF
--- a/src/interactions/buttons/oldPanelWarning.ts
+++ b/src/interactions/buttons/oldPanelWarning.ts
@@ -1,0 +1,18 @@
+import { ButtonHandler } from "../../types/Interactions";
+import { onError } from "../../utils/onError";
+
+const button: ButtonHandler = {
+  customId: "openTicket",
+  async execute(client, data, interaction) {
+    interaction.reply(
+      (
+        await onError(
+          "Commands",
+          "This is an old panel and can no longer be used. If you are a server admin, please run /panel to create a new panel"
+        )
+      ).discordMsg
+    );
+  },
+};
+
+export default button;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new button interaction that notifies users when attempting to use an outdated panel, advising server administrators to create a new one using the appropriate command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->