### PR TITLE
Potential fix for code scanning alert no. 25: Database query built from user-controlled sources

### DIFF
--- a/src/apiServer.ts
+++ b/src/apiServer.ts
@@ -417,7 +417,7 @@ export function startApi(port: number) {
           break;
         // In this case _id is of the server we want the messages of
         case "tags":
-          const tags = await TagSchema.find({ server: _id });
+          const tags = await TagSchema.find({ server: { $eq: _id } });
           await updateCachedData(`tags:${_id}`, 30, tags);
           res.status(200).json({
             message: `Tags have been added to the cache. It can be accessed through tags:${_id}`,
@@ -426,14 +426,14 @@ export function startApi(port: number) {
           break;
         case "interactive":
           const interactive = [
-            ...(await TagSchema.find({ server: _id })).map((t) => ({
+            ...(await TagSchema.find({ server: { $eq: _id } })).map((t) => ({
               _id: t._id,
               name: t.name,
             })),
-            ...(await ApplicationTriggerSchema.find({ server: _id })).map(
+            ...(await ApplicationTriggerSchema.find({ server: { $eq: _id } })).map(
               (t) => ({ _id: t._id, name: t.name })
             ),
-            ...(await TicketTriggerSchema.find({ server: _id })).map((t) => ({
+            ...(await TicketTriggerSchema.find({ server: { $eq: _id } })).map((t) => ({
               _id: t._id,
               name: t.label,
             })),


### PR DESCRIPTION
Potential fix for [https://github.com/ThreadedTickets/Bot/security/code-scanning/25](https://github.com/ThreadedTickets/Bot/security/code-scanning/25)

To fix this vulnerability, we need to ensure that the user-provided `_id` is interpreted as a literal value and not as a query object. The best way to do this in MongoDB is to use the `$eq` operator, i.e., `{ server: { $eq: _id } }`, which forces MongoDB to treat `_id` as a value, not as a query object. This change should be applied to all instances in the `/forceCache` endpoint where `{ server: _id }` is used in a query, specifically on lines 420, 429, 433, and 436. No new imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
