### PR TITLE
Potential fix for code scanning alert no. 5: Prototype-polluting function

### DIFF
--- a/src/utils/tickets/TranscriptManager.ts
+++ b/src/utils/tickets/TranscriptManager.ts
@@ -231,10 +231,17 @@ export class TranscriptWriter {
     const parts = path.split(".");
     let current = this.metadata;
     for (let i = 0; i < parts.length - 1; i++) {
+      if (parts[i] === "__proto__" || parts[i] === "constructor") {
+        throw new Error("Invalid property name detected.");
+      }
       if (!current[parts[i]]) current[parts[i]] = {};
       current = current[parts[i]];
     }
-    current[parts[parts.length - 1]] = value;
+    const lastPart = parts[parts.length - 1];
+    if (lastPart === "__proto__" || lastPart === "constructor") {
+      throw new Error("Invalid property name detected.");
+    }
+    current[lastPart] = value;
     this.saveMeta();
   }
 


### PR DESCRIPTION
Potential fix for [https://github.com/ThreadedTickets/Bot/security/code-scanning/5](https://github.com/ThreadedTickets/Bot/security/code-scanning/5)

To fix the issue, we need to prevent prototype pollution by blocking dangerous property names such as `__proto__` and `constructor` during the traversal and assignment process in the `setMeta` function. This can be achieved by adding a check to skip these property names when iterating through the `parts` array.

Specifically:
1. Add a validation step to ensure that `parts[i]` and `parts[parts.length - 1]` are not `__proto__`, `constructor`, or any other dangerous property names.
2. If a dangerous property name is detected, throw an error or skip the assignment to prevent prototype pollution.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
