### PR TITLE
Potential fix for code scanning alert no. 7: Database query built from user-controlled sources

### DIFF
--- a/src/apiServer.ts
+++ b/src/apiServer.ts
@@ -81,9 +81,9 @@ export function startApi(port: number) {
     const creatorId = req.query.id;
     const { content, embeds, attachments, components } = req.body as Body;
 
-    if (!creatorId) {
+    if (!creatorId || typeof creatorId !== "string") {
       res.status(400).json({
-        message: "Please provide a creatorId ID (?id=) and data in the body",
+        message: "Please provide a valid creatorId (?id=) as a string and data in the body",
       });
       return;
     }


### PR DESCRIPTION
Potential fix for [https://github.com/ThreadedTickets/Bot/security/code-scanning/7](https://github.com/ThreadedTickets/Bot/security/code-scanning/7)

To fix the problem, we need to ensure that the value of `creatorId` is a literal string (or a valid ObjectId) and not a query object or other potentially malicious value. The best way to do this is to check the type of `creatorId` before using it in the query. If it is not a string, we should return an error and avoid running the query. This change should be made in the `/create/message/save` route handler, just before any database queries that use `creatorId` (specifically before line 92 and line 150). No new methods or imports are needed, as this can be done with a simple type check.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
